### PR TITLE
Append SUBSYSTEM to the env data read for uevent files before matching

### DIFF
--- a/crawler/device.go
+++ b/crawler/device.go
@@ -53,14 +53,14 @@ func ExistingDevices(queue chan Device, errors chan error, matcher netlink.Match
 					return err
 				}
 
+				kObj := filepath.Dir(path)
+
+				// Append to env subsystem if existing
+				if link, err := os.Readlink(kObj + "/subsystem"); err == nil {
+					env["SUBSYSTEM"] = filepath.Base(link)
+				}
+
 				if matcher == nil || matcher.EvaluateEnv(env) {
-
-					kObj := filepath.Dir(path)
-
-					// Append to env subsystem if existing
-					if link, err := os.Readlink(kObj + "/subsystem"); err == nil {
-						env["SUBSYSTEM"] = filepath.Base(link)
-					}
 
 					queue <- Device{
 						KObj: kObj,


### PR DESCRIPTION
Matching based on the SUBSYSTEM env key is not possible with ExistingDevices because the SUBSYTEM key is only inserted into env after matcher is already evaluated to true.

This PR fixes it (issue #1 )