### PR TITLE
Check for Recvfrom error

### DIFF
--- a/netlink/conn.go
+++ b/netlink/conn.go
@@ -66,7 +66,10 @@ func (c *UEventConn) ReadMsg() (msg []byte, err error) {
 	}
 
 	// Now read complete data
-	n, _, _ = syscall.Recvfrom(c.Fd, buf, 0)
+	n, _, err = syscall.Recvfrom(c.Fd, buf, 0)
+	if err != nil {
+		return
+	}
 
 	// Extract only real data from buffer and return that
 	msg = buf[:n]


### PR DESCRIPTION
I think the following PR should prevent the panic that I'm experiencing on VMs in our automated test environment:

```
Jun 11 14:38:34 jun111628-661587 snapd[13155]: panic: runtime error: slice bounds out of range
Jun 11 14:38:34 jun111628-661587 snapd[13155]: goroutine 15 [running]:
Jun 11 14:38:34 jun111628-661587 snapd[13155]: panic(0x556b13061ea0, 0xc82000a070)
Jun 11 14:38:34 jun111628-661587 snapd[13155]:         /usr/lib/go-1.6/src/runtime/panic.go:481 +0x3ea
Jun 11 14:38:34 jun111628-661587 snapd[13155]: github.com/snapcore/snapd/vendor/github.com/pilebones/go-udev/netlink.(*UEventConn).ReadMsg(0xc820322320, 0x0, 0x0, 0x0, 0x0, 0x0)
Jun 11 14:38:34 jun111628-661587 snapd[13155]:         /home/gopath/src/github.com/snapcore/snapd/_build/src/github.com/snapcore/snapd/vendor/github.com/pilebones/go-udev/netlink/conn.go:72 +0x148
Jun 11 14:38:34 jun111628-661587 snapd[13155]: github.com/snapcore/snapd/vendor/github.com/pilebones/go-udev/netlink.(*UEventConn).ReadUEvent(0xc820322320, 0x0, 0x0, 0x0)
Jun 11 14:38:34 jun111628-661587 snapd[13155]:         /home/gopath/src/github.com/snapcore/snapd/_build/src/github.com/snapcore/snapd/vendor/github.com/pilebones/go-udev/netlink/conn.go:79 +0x33
Jun 11 14:38:34 jun111628-661587 snapd[13155]: github.com/snapcore/snapd/vendor/github.com/pilebones/go-udev/netlink.(*UEventConn).Monitor.func1(0xc820327f20, 0xc820322320, 0xc820326420, 0x0, 0x0, 0xc8203263c0)
Jun 11 14:38:34 jun111628-661587 snapd[13155]:         /home/gopath/src/github.com/snapcore/snapd/_build/src/github.com/snapcore/snapd/vendor/github.com/pilebones/go-udev/netlink/conn.go:109 +0x8a
Jun 11 14:38:34 jun111628-661587 snapd[13155]: created by github.com/snapcore/snapd/vendor/github.com/pilebones/go-udev/netlink.(*UEventConn).Monitor
Jun 11 14:38:34 jun111628-661587 snapd[13155]:         /home/gopath/src/github.com/snapcore/snapd/_build/src/github.com/snapcore/snapd/vendor/github.com/pilebones/go-udev/netlink/conn.go:124 +0x239
```
