### PR TITLE
Close crawler channel when filepath.Walk is done, fixed help string.

### DIFF
--- a/crawler/device.go
+++ b/crawler/device.go
@@ -74,6 +74,7 @@ func ExistingDevices(queue chan Device, errors chan error, matcher netlink.Match
 		if err != nil {
 			errors <- err
 		}
+		close(queue)
 	}()
 	return quit
 }

--- a/main.go
+++ b/main.go
@@ -24,7 +24,7 @@ var (
 func init() {
 	filePath = flag.String("file", "", "Optionnal input file path with matcher-rules (default: no matcher)")
 	monitorMode = flag.Bool("monitor", false, "Enable monitor mode")
-	infoMode = flag.Bool("info", false, "Enable monitor mode")
+	infoMode = flag.Bool("info", false, "Enable crawler mode")
 }
 
 func main() {
@@ -73,7 +73,11 @@ func info(matcher netlink.Matcher) {
 	// Handling message from queue
 	for {
 		select {
-		case device := <-queue:
+		case device, more := <-queue:
+			if !more {
+				log.Printf("Finished processing existing devices\n")
+				return
+			}
 			log.Printf("Detect device at %s with env %v\n", device.KObj, device.Env)
 		case err := <-errors:
 			log.Printf("ERROR: %v", err)


### PR DESCRIPTION
Close devices channel in the crawler when done with filepath.Walk so that the receiver knows no more devices are coming.

I'm not sure if this is the best way of doing this, so I'm open to discuss/change this. One alternative would be to have a dedicated 'done' channel and send `struct{}` to it.