### PR TITLE
Fix len check

### DIFF
--- a/netlink/uevent.go
+++ b/netlink/uevent.go
@@ -100,7 +100,7 @@ func parseUdevEvent(raw []byte) (e *UEvent, err error) {
 
 	// the payload offset int is stored in native byte order.
 	payloadoff := *(*uint32)(unsafe.Pointer(&raw[16]))
-	if int(payloadoff) >= len(raw) {
+	if payloadoff >= uint32(len(raw)) {
 		return nil, fmt.Errorf("cannot parse libudev event: invalid data offset")
 	}
 


### PR DESCRIPTION
Followup to my yesterday's PR - fix for length check - casting to int in the invalid len test gives negative value and it only manifests itself with a panic on 32-bit systems:
```
=== RUN   TestParseUdevEvent
--- FAIL: TestParseUdevEvent (0.00s)
panic: runtime error: slice bounds out of range [recovered]
	panic: runtime error: slice bounds out of range

goroutine 8 [running]:
panic(0x81692a0, 0x18420010)
	/usr/lib/go-1.6/src/runtime/panic.go:481 +0x326
testing.tRunner.func1(0x184c8e40)
	/usr/lib/go-1.6/src/testing/testing.go:467 +0x14f
panic(0x81692a0, 0x18420010)
	/usr/lib/go-1.6/src/runtime/panic.go:443 +0x3fd
github.com/snapcore/snapd/osutil/udev/netlink.parseUdevEvent(0x18414370, 0x42, 0x50, 0x0, 0x0, 0x0)
	github.com/snapcore/snapd/osutil/udev/netlink/_test/_obj_test/uevent.go:133 +0x846
github.com/snapcore/snapd/osutil/udev/netlink.ParseUEvent(0x18414370, 0x42, 0x50, 0x0, 0x0, 0x0)
	github.com/snapcore/snapd/osutil/udev/netlink/_test/_obj_test/uevent.go:178 +0x153
github.com/snapcore/snapd/osutil/udev/netlink.TestParseUdevEvent(0x184c8e40)
	/tmp/static-unit-tests/src/github.com/snapcore/snapd/osutil/udev/netlink/uevent_test.go:178 +0x866
testing.tRunner(0x184c8e40, 0x8236c04)
	/usr/lib/go-1.6/src/testing/testing.go:473 +0x8f
created by testing.RunTests
	/usr/lib/go-1.6/src/testing/testing.go:582 +0x6f2
exit status 2
FAIL	github.com/snapcore/snapd/osutil/udev/netlink	0.005s
```