### PR TITLE
Let the kernel set nl_pid automatically

### DIFF
--- a/netlink/conn.go
+++ b/netlink/conn.go
@@ -40,7 +40,6 @@ func (c *UEventConn) Connect(mode Mode) (err error) {
 	c.Addr = syscall.SockaddrNetlink{
 		Family: syscall.AF_NETLINK,
 		Groups: uint32(mode),
-		Pid:    uint32(os.Getpid()),
 	}
 
 	if err = syscall.Bind(c.Fd, &c.Addr); err != nil {


### PR DESCRIPTION
Setting the netlink nl_pid to the pid is problematic if you want to use
multiple netlink connections in the same application or the application
runs in another pid namespace (nl_pid needs to to system-wide unique).

With nl_pid==0 the kernel automatically assigns a unique nl_pid.