### PR TITLE
docker: add multistage manifest and update related doc

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+LICENSE
+readme.md
+matcher.sample
+.git

--- a/Dockfile.multistage
+++ b/Dockfile.multistage
@@ -1,0 +1,14 @@
+## Build
+FROM golang:1.18.0-alpine3.15 AS builder
+WORKDIR /build
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+ADD . /build
+RUN CGO_ENABLED=0 go build -o /go-udev
+
+## Deploy
+FROM alpine:latest
+WORKDIR /
+COPY --from=builder /go-udev /go-udev
+ENTRYPOINT ["/go-udev"]

--- a/README.md
+++ b/README.md
@@ -107,6 +107,26 @@ You could pass this file using for both mode:
 
 ```
 
+## Docker usage
+
+### How to build docker image
+```
+docker build . -f Dockfile.multistage -t go-udev
+```
+
+### How to execute `go-udev -info` using docker image
+```
+docker run -rm -t go-udev -info
+```
+
+### How to execute `go-udev -monitor` using docker image
+```
+docker run --rm -v=/dev:/dev -v /run/udev:/run/udev:ro --net=host -t go-udev -monitor
+```
+Warning: unsafe method because we share host /dev directory to the container.
+
+*__TODO__: unsafe and `-monitor` is not fully functional in docker, fix working in progress...*
+
 ## Throubleshooting
 
 Don't hesitate to notice if you detect a problem with this tool or library.


### PR DESCRIPTION
Add Dockerfile for both `-info` and `-monitor` mode.

Related to #23