### PR TITLE
mimic libudev.h functions for some properties

### DIFF
--- a/netlink/uevent.go
+++ b/netlink/uevent.go
@@ -177,3 +177,11 @@ func ParseUEvent(raw []byte) (e *UEvent, err error) {
 	}
 	return
 }
+
+func (e UEvent) Devnode() string {
+	return e.Env["DEVNAME"]
+}
+
+func (e UEvent) Syspath() string {
+	return "/sys" + e.KObj
+}


### PR DESCRIPTION
I am using this on a small project and I required the Devnode and Syspath of a hardware device, I was not sure what property they were in the netlink.UEvent.Env map and I had to dig through the source of systemd and several other sources to find out, I figured it'd be nice if they had aliases that were closer to libudev.h