### PR TITLE
Linter and link fixes, allow handling of "abort error"

### DIFF
--- a/crawler/device.go
+++ b/crawler/device.go
@@ -57,9 +57,6 @@ func ExistingDevices(queue chan Device, errs chan error, matcher netlink.Matcher
 				}
 
 				kObj := filepath.Dir(path)
-				if !strings.HasPrefix(kObj, SYSFS_ROOT) {
-					return fmt.Errorf("invalid kernel object path: %s", kObj)
-				}
 
 				// Append to env subsystem if existing
 				if link, err := os.Readlink(kObj + "/subsystem"); err == nil {

--- a/crawler/device.go
+++ b/crawler/device.go
@@ -87,7 +87,7 @@ func getEventFromUEventFile(path string) (map[string]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	return getEventFromUEventData(data), nil
+	return getEventFromUEventData(data)
 }
 
 // syntax: name=value for each line

--- a/crawler/device.go
+++ b/crawler/device.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -80,19 +79,9 @@ func ExistingDevices(queue chan Device, errs chan error, matcher netlink.Matcher
 	return quit
 }
 
-// getEventFromUEventFile return all env var define in file
-// syntax: name=value for each line
-// Fonction use for /sys/.../uevent files
+// getEventFromUEventFile return all variables defined in /sys/**/uevent files
 func getEventFromUEventFile(path string) (map[string]string, error) {
-	f, err := os.Open(path)
-	if err != nil {
-		return nil, err
-	}
-	defer func() {
-		_ = f.Close()
-	}()
-
-	data, err := io.ReadAll(f)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/crawler/device_test.go
+++ b/crawler/device_test.go
@@ -66,10 +66,6 @@ DEVNAME=vcs3`,
 			t.Fatalf("Test %d failed, unable to get event dfrom uevent file", k)
 		}
 
-		if !reflect.DeepEqual(evt, getEventFromUEventData([]byte(tcase.got))) {
-			t.Fatalf("Test %d failed, uevent from file or data must be equals", k)
-		}
-
 		if !reflect.DeepEqual(evt, tcase.expected) {
 			t.Fatalf("Test %d failed (got: %v, expected: %v)", k, evt, tcase.expected)
 		}

--- a/netlink/conn.go
+++ b/netlink/conn.go
@@ -33,8 +33,8 @@ type UEventConn struct {
 // Connect allow to connect to system socket AF_NETLINK with family NETLINK_KOBJECT_UEVENT to
 // catch events about block/char device
 // see:
-// - http://elixir.free-electrons.com/linux/v3.12/source/include/uapi/linux/netlink.h#L23
-// - http://elixir.free-electrons.com/linux/v3.12/source/include/uapi/linux/socket.h#L11
+// - https://elixir.bootlin.com/linux/v6.14.1/source/include/uapi/linux/netlink.h#L23
+// - https://elixir.bootlin.com/linux/v6.14.1/source/include/uapi/linux/socket.h#L11
 func (c *UEventConn) Connect(mode Mode) (err error) {
 	if c.Fd, err = syscall.Socket(syscall.AF_NETLINK, syscall.SOCK_RAW, syscall.NETLINK_KOBJECT_UEVENT); err != nil {
 		return

--- a/netlink/uevent.go
+++ b/netlink/uevent.go
@@ -9,7 +9,7 @@ import (
 	"unsafe"
 )
 
-// See: http://elixir.free-electrons.com/linux/v3.12/source/lib/kobject_uevent.c#L45
+// See: https://elixir.bootlin.com/linux/v6.14.1/source/lib/kobject_uevent.c#L50
 
 const (
 	ADD     KObjAction = "add"


### PR DESCRIPTION
This is a group of a couple of fixes:

1. go-staticcheck says that error messages shouldn't begin with capital letters. So I downcased them.
2. `return errors.New("abort signal receive")` was present in the middle of a function during the crawling of `/sys/devices`. That makes it so that we can't distinguish between that particular error and any other error (at least, not easily). That error is special because it's one that's actually triggered by the user just to stop the crawling process, so the user is very likely to treat it as not an error. This makes that possible.
3. `ioutil` has been deprecated for a long time now, so I replaced that with `io.*` or `os.*`.
4. It was very helpful of you to include links to kernel source where applicable. Unfortunately those links died, so I replaced them with working ones.